### PR TITLE
Fix for issue #669

### DIFF
--- a/src/yetibot/commands/catfacts.clj
+++ b/src/yetibot/commands/catfacts.clj
@@ -3,13 +3,26 @@
     [yetibot.core.hooks :refer [cmd-hook]]
     [yetibot.core.util.http :refer [get-json]]))
 
-(def endpoint "http://catfacts-api.appspot.com/api/facts")
+(def endpoint-ptrn "http://www.catfact.info/api/v1/facts.json?page=%d&per_page=1")
+
+(defonce total-facts (atom nil))
+
+(defn- fetch-catfact
+  "Fetches the catfact with the given id (>0) and returns its json map"
+  [id]
+  (get-json (format endpoint-ptrn id)))
+
+(defn- get-total-facts
+  "Gets the total number of facts, if not known fetch the total and return it"
+  []
+  (or @total-facts (:total (fetch-catfact 0))))
 
 (defn catfact
   "catfact # fetch a random cat fact"
   {:yb/cat #{:fun}}
-  [_] (let [res (get-json endpoint)]
-        (first (:facts res))))
+  [_] (let [catmap (fetch-catfact (inc (rand-int (get-total-facts))))]
+        (reset! total-facts (:total catmap))
+        (:details (first (:facts catmap)))))
 
 (cmd-hook #"catfact"
           _ catfact)


### PR DESCRIPTION
This is an attempt to fix issue #669 "catfact is dead 😿" by switching from the dead catfacts-api to catfacts.info.

Since [catfacts.info](http://www.catfact.info/) doesn't allow for random catfacts requests, it will instead fetch for a single page through http://www.catfact.info/api/v1/facts.json?page=1&per_page=1 with a random page id from 1 to total. The first request made will do two requests, one to obtain the total number of facts to generate the random page id with, and then a request for the random fact. After that point, the total number is stored in an atom, and updated each time a request is made.

Long live catfacts 🐱