### PR TITLE
Fixed Docker Compose env var Slack example

### DIFF
--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -26,8 +26,8 @@ config like:
 
 ```yaml
     environment:
-      - YB_ADAPTERS_MYSLACK_TYPE=Slack
-      - YB_ADAPTERS_MYSLACK_TOKEN=xoxb-my-token
+      - YB_ADAPTERS_SLACK_TYPE=slack
+      - YB_ADAPTERS_SLACK_TOKEN=xoxb-my-token
       - YB_DB_URL=postgresql://yetibot:yetibot@postgres:5432/yetibot
 ```
 


### PR DESCRIPTION
A tiny change I had to make to get Yetibot, running locally via `docker-compose`, to connect to my Slack workspace.  These vars are correctly specified in `doc/DOCKER.md`.

Thanks for such a fun project!
