### PR TITLE
Add command for fetching the latest release info from a github repo

### DIFF
--- a/src/yetibot/api/github.clj
+++ b/src/yetibot/api/github.clj
@@ -120,6 +120,14 @@
   (with-url endpoint
     (r/specific-release org-name repo "latest")))
 
+(defn release-by-tag [org-name repo tag]
+  (with-url endpoint
+    (r/specific-release-by-tag org-name repo tag)))
+
+(defn releases [org-name repo]
+  (with-url endpoint
+    (r/releases org-name repo)))
+
 (defn sum-weekly
   "Takes the weekly stats for an author and sums them into:
    {:a 0 :d 0 :c 0}

--- a/src/yetibot/api/github.clj
+++ b/src/yetibot/api/github.clj
@@ -116,6 +116,10 @@
   (with-url endpoint
     (r/code-frequency org-name repo auth)))
 
+(defn latest-releases [org-name repo]
+  (with-url endpoint
+    (r/specific-release org-name repo "latest")))
+
 (defn sum-weekly
   "Takes the weekly stats for an author and sums them into:
    {:a 0 :d 0 :c 0}

--- a/src/yetibot/commands/github.clj
+++ b/src/yetibot/commands/github.clj
@@ -145,9 +145,10 @@
           author (get-in release [:author :login])
           published-at (-> "YYYY-MM-dd'T'HH:mm:ssZ"
                            (f/formatter)
-                           (f/parse (:published_at release)))]
-      (format "Release version, tagged: %s from %s/%s, was published on %s by %s" tag org-name repo
-              (f/unparse date-hour-formatter published-at) author))
+                           (f/parse (:published_at release)))
+          body (:body release)]
+      (format "Release version, tagged: %s from %s/%s, was published on %s by %s\n %s" tag org-name repo
+              (f/unparse date-hour-formatter published-at) author body))
     (format "No release version info found for %s/%s" org-name repo)))
 
 (defn show-latest-release-info-cmd

--- a/src/yetibot/commands/github.clj
+++ b/src/yetibot/commands/github.clj
@@ -136,6 +136,22 @@
                   (f/unparse date-formatter datetime))))
       (str n " is not a number"))))
 
+(defn releases-cmd
+  "gh releases <org>/<repo-name> # retrieve info about the latest release on a github repository"
+  {:yb/cat #{:util :info}}
+  [{[_ org-name repo] :match chat-source :chat-source}]
+  (let [latest-release (gh/latest-releases org-name repo)
+        status (:status latest-release)]
+    (if (nil? status)
+      (let [tagname (:tag_name latest-release)
+            author (get-in latest-release [:author :login])
+            published-at (:published_at (-> "YYYY-MM-dd'T'HH:mm:ssZ"
+                                            (f/formatter)
+                                            (f/parse (:published_at latest-release))))]
+        (format "%s/%s latest version tagged: %s, was published on %s by %s " org-name repo tagname
+                (f/unparse (f/formatter "MMM d, yyyy 'at' hh:mm") published-at) author))
+      (format "No release version info found for %s/%s" org-name repo))))
+
 
 (when (gh/configured?)
   (cmd-hook ["gh" #"^gh|github$"]
@@ -154,4 +170,5 @@
             #"stats\s+(\S+)\/(\S+)" stats-cmd
             #"contributors\s+(\S+)\/(\S+)\s+since\s+(\d+)\s+(minutes*|hours*|days*|weeks*|months*)" contributors-since-cmd
             #"tags\s+(\S+)\/(\S+)" tags
-            #"branches\s+(\S+)\/(\S+)" branches))
+            #"branches\s+(\S+)\/(\S+)" branches
+            #"releases\s+(\S+)\/(\S+)" releases-cmd))

--- a/src/yetibot/commands/github.clj
+++ b/src/yetibot/commands/github.clj
@@ -155,21 +155,21 @@
   "gh releases show <org>/<repo-name> # retrieve info about the latest release on a Github repository"
   {:yb/cat #{:util :info}}
   [{[_ org-name repo] :match}]
-  (if-let [release (gh/latest-releases org-name repo)]
+  (let [release (gh/latest-releases org-name repo)]
     (format-release release org-name repo)))
 
 (defn show-release-info-by-tag-cmd
   "gh releases show <org>/<repo-name> <tag> # retrieve info about a specific release tag on a Github repository"
   {:yb/cat #{:util :info}}
   [{[_ org-name repo tag] :match}]
-  (if-let [release (gh/release-by-tag org-name repo tag)]
+  (let [release (gh/release-by-tag org-name repo tag)]
     (format-release release org-name repo)))
 
 (defn list-releases-info-cmd
   "gh releases <org>/<repo-name> # list releases for a Github repository"
   {:yb/cat #{:util :info}}
   [{[_ org-name repo] :match}]
-  (let [releases (gh/releases org-name repo)]
+  (if-let [releases (gh/releases org-name repo)]
     (for [release releases]
       (let [tag (:tag_name release)
             author (get-in release [:author :login])
@@ -177,7 +177,8 @@
                              (f/formatter)
                              (f/parse (:published_at release)))]
         (format "Release version tagged: %s, from %s/%s, was published on %s by %s" tag org-name repo
-                (f/unparse date-hour-formatter published-at) author)))))
+                (f/unparse date-hour-formatter published-at) author)))
+    (format "No releases found on %s/%s" org-name repo)))
 
 (when (gh/configured?)
   (cmd-hook ["gh" #"^gh|github$"]


### PR DESCRIPTION
Hey guys,

Sorry that it took so long for me to come back for this PR but I wanted to get a little bit acquainted with the project (real beginner here ^^). In the end though, it feels good to learn some new stuff ;-) and fortunately, here is the first PR I can come up with.

This one is related to issue #729 : we wanted a command for fetching infos about the latest release on a github repository.
The syntax for the command is quite simple : 

`!gh releases org-name/repo`

Here are some screenshots of how it renders :

1. When simply asking the bot to fetch the latest release info
![gh_simple_call](https://user-images.githubusercontent.com/847920/47597118-27bac300-d98c-11e8-9c11-c3f77bf1b5f3.png)

2. When asking for release infos which are, unfortunately, unavailable
![gh_releases_no_info_found](https://user-images.githubusercontent.com/847920/47597132-44ef9180-d98c-11e8-86c7-18325a663f44.png)

3. When used with the already existing `cron` command
![gh_releases_result_on_cron](https://user-images.githubusercontent.com/847920/47597143-66e91400-d98c-11e8-8e79-a0967acd5289.png)

I hope my code is not too ugly ^^ but anyway, feel free to let me know of any changes that you want me to incorporate into the PR. I'd be glad to have your feedback especially on the _Clojure idioms_ or anything else that can be improved.

thanks a lot for the opportunity o/