### PR TITLE
Fix Scala evaluation command

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,7 @@
                  ; utils
                  [org.flatland/useful "0.11.5"]
                  ; << string interpolation macro
-                 [org.clojure/core.incubator "0.1.4"] 
+                 [org.clojure/core.incubator "0.1.4"]
                  ; graphql
                  [district0x/graphql-query "1.0.5"]
 
@@ -63,7 +63,12 @@
                  [bultitude "0.2.8"]
 
                  ;encoding
-                 [org.clojure/data.codec "0.1.1"]]
+                 [org.clojure/data.codec "0.1.1"]
+
+                 ;sse
+                 [io.nervous/kvlt "0.1.4"]
+                 ;; overwrite kvlt's outdated version of aleph
+                 [aleph "0.4.6"]]
 
   :plugins [[lein-exec "0.3.5"]
             [lein-environ "1.0.3"]

--- a/src/yetibot/commands/scala.clj
+++ b/src/yetibot/commands/scala.clj
@@ -4,51 +4,105 @@
     [yetibot.core.hooks :refer [cmd-hook]]
     [clj-http.client :as client]
     [clojure.string :as s]
-    [cheshire.core :as json]))
+    [cheshire.core :as json]
+    [kvlt.core :as kvlt]
+    [clojure.core.async :as async]))
 
-(def endpoint "http://www.scalakata.com/api/com/scalakata/Api/eval")
+(def endpoint "https://scastie.scala-lang.org/api/")
 
-(defn make-body [scala-str]
-  {:code
-   (str
-     "import com.scalakata._; @instrument class Playground {"
-     scala-str
-     "}")})
+(def sbt-config-extra "scalacOptions ++= Seq(\"-deprecation\",  \"-encoding\", \"UTF-8\",  \"-feature\",  \"-unchecked\")")
+
+(def scala-version "2.12.6")
+
+(def platform "Jvm")
+
+(defn make-body
+  [scala-str]
+  (json/generate-string {:_isWorksheetMode       true
+                         :code                   scala-str
+                         :target                 {:scalaVersion scala-version
+                                                  :$type        platform}
+                         :libraries              []
+                         :librariesFromList      []
+                         :sbtConfigExtra         sbt-config-extra
+                         :sbtPluginsConfigExtra  ""
+                         :isShowingInUserProfile false}))
 
 (defn try-scala
+  "Submits the Scala expression to the evaluation API and returns a
+  Server-Sent Events core.async channel for retrieving the result."
   [expr]
   (info "scala:" expr)
-  (client/post
-    endpoint
-    {:body
-     (json/generate-string {:request (json/generate-string (make-body expr))})
-     :as :json}))
+  (as-> (str endpoint "run") v
+        (client/post v {:content-type :json
+                        :accept       :json
+                        :body         (make-body expr)})
+        (:body v)
+        (json/parse-string v true)
+        (:base64UUID v)
+        (str endpoint "progress-sse/" v)
+        (kvlt/event-source! v)))
 
-(defn extract-success [body]
-  (let [instrs (:instrumentation body)]
-    (map
-      (fn [[coords {:keys [className v]}]] (format "%s: %s" v className))
-      instrs)))
+(defn extract-success
+  "Extracts success evaluation info from the SSE-message data."
+  [{user-output :userOutput instrumentations :instrumentations}]
+  (cond
+    (seq user-output) (get-in user-output [:line])
+    (seq instrumentations) (->> instrumentations
+                                (map (fn [{{v :v className :className} :render}]
+                                       (format "%s: %s" v className)))
+                                (s/join "\n"))))
 
-(defn extract-result [resp]
-  (let [body (:body resp)]
-    (cond
-      ;; timeout
-      (:timeout body) (str "The expression timed out")
-      ;; runtime error(s)
-      (seq (:runtimeError body)) (map :message (:runtimeError body))
-      ;; compilation error(s)
-      (seq (:complilationInfos body)) (mapcat
-                                        (fn [[_ msgs]] (map :message msgs))
-                                        (:complilationInfos body))
-      ;; success
-      :else (extract-success body))))
+(defmulti format-result
+          "Returns a dispatch-value based on the SSE data received from the evaluation API."
+          (fn [{:keys [compilationInfos isTimeout isDone]}]
+            (cond
+              (true? isTimeout) :eval-timeout
+              (seq compilationInfos) :eval-runtime-error
+              (true? isDone) :is-done
+              :else :eval-success)))
+
+(defmethod format-result :eval-timeout
+  [_]
+  (str "The expression timed out"))
+
+(defmethod format-result :eval-runtime-error
+  [data]
+  (->> data
+       :compilationInfos
+       (map :message)
+       (s/join "\n")))
+
+(defmethod format-result :is-done
+  [_]
+  :is-done)
+
+(defmethod format-result :eval-success
+  [data]
+  (extract-success data))
+
+(defn extract-result
+  "Extracts the Scala evaluation result from the core.async channel provided
+   as argument."
+  [chan]
+  (async/go-loop [results []]
+    (let [result (as-> (async/<! chan) v
+                       (json/parse-string (:data v) true)
+                       (format-result v))]
+      (if (= :is-done result)
+        (do
+          (async/close! chan)
+          (->> results
+               (remove nil?)
+               (s/join "\n")))
+        (recur (conj results result))))))
 
 (defn scala-cmd
   "scala <expression> # evaluate a scala expression"
   {:yb/cat #{:repl}}
   [{expr :match}]
-  (extract-result (try-scala expr)))
+  (async/<!!
+    (extract-result (try-scala expr))))
 
 (cmd-hook #"scala"
           #".*" scala-cmd)


### PR DESCRIPTION
hey guys,

Sorry that it took so long to deliver this one but I had some fun (and struggles ^^) learning some new stuff along the way while implementing it ;-)...
by the way, thanks a lot @devth for helping me out when I was stuck : you provided valuable insights ... I owe you a beer (or two hehe)

So, what do we have here :

- First of all, instead of using the now _deprecated_ `scalakata` API, we now target the new `scastie` Scala evaluation API which uses _Server-Sent Events (SSE)_ for sending back the results.

- A small utilitiy lib, `[io.nervous/kvlt "0.1.4"]`, has then been introduced to handle these SSEs. `kvlt` provides an abstraction based on `core.async` channels for handing out the incoming events from the server.

- There are some _parameters_ related to the evaluation API (api endpoint url, scala-version etc.) that have been hardcoded. Should I have these parameters set in the config file or is it okay to leave them here? and in the former case, do I have to make a PR to `yetibot.core` for the _new set of parameters_ then?


Here are some screenshots of how it renders so far :

**Evaluation success with output**

![scala_cmd_on_success](https://user-images.githubusercontent.com/847920/49692208-4dbfaf80-fb55-11e8-9275-c3ce85c2916a.png)


**Evaluation success without output** (no explicit _println_)

![scala_cmd_no_output_eval](https://user-images.githubusercontent.com/847920/49692213-721b8c00-fb55-11e8-9da1-c78498cf3865.png)


**Evaluation errors**

![scala_cmd_on_eval_error](https://user-images.githubusercontent.com/847920/49692221-91b2b480-fb55-11e8-9ab1-fe89d9880259.png)

There are some stuff that we could improve on :

- It can be cool to have some `clojure.specs` validating the data we send/retrieve from the server. I have seen that there are some good stuff that have been implemented on `karma` (good job @jcorrado ^^, I will _shamelessly_ take some inspiration from what you've done ;-)). I will probably add them from another branch as a refinement.

- We will have to fix the _tests_ as well : they have been _disabled_ since the API deprecation if I'm not wrong. I would like to work on it but since there is already a related issue #612 , I thought it would be better to work on it from another branch as well.

anyway, feel free to check out this branch and play around with it guys and as usual, do not hesitate to ping me for any suggestions/improvements that you want me to add to this patch.

thanks a lot...