### PR TITLE
Add error handling support for http 429

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -6,6 +6,11 @@ which contains Yetibot's core functionality along with a few commands. See
 changelog](https://github.com/yetibot/yetibot.core/blob/master/doc/CHANGELOG.md)
 as well.
 
+## 0.5.15 - Unreleased
+
+- Handle `429` errors from Weatherbit in the weather command
+  [#904](https://github.com/yetibot/yetibot/pull/904)
+
 ## 0.5.14 - 3/25/2019
 
 - Upgrade to yetibot.core 0.5.12

--- a/src/yetibot/commands/weather.clj
+++ b/src/yetibot/commands/weather.clj
@@ -52,9 +52,10 @@
     (get-by-pc path pc cc)
     (get-by-name path loc)))
 
-(defn- error-response [{:keys [error]}]
-  (when error
-    {:result/error error}))
+(defn- error-response [{:keys [error status_code status_message]}]
+  (cond
+    error {:result/error error}
+    (= 429 status_code) {:result/error status_message}))
 
 (defn c-to-f [c] (-> (* c 9/5) (+ 32) float))
 (defn km-to-mi [km] (-> (/ km 1.609) float))


### PR DESCRIPTION
If API quota is passed, Weatherbit will return a `:body` like:

```clojure
{:status_code 429
 :status_message "Your request count (1007) is over the allowed limit of 1000 per day - Upgrade your key, or retry after 1343.2 minutes"}
```

This change handles it, e.g.:

![image](https://user-images.githubusercontent.com/86107/55200968-60063d80-5186-11e9-8f92-fbd0e39d7568.png)
