### PR TITLE
Dockerfile CMD should be list separated by commas.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ VOLUME $WORKDIR/config/
 
 VOLUME $LOGDIR
 
-CMD ["lein", "with-profile" "+docker" "run"]
+CMD ["lein", "with-profile", "+docker", "run"]


### PR DESCRIPTION
I talked with @devth about this at Clojure/North, while I was debugging the startup of the app. 


