### PR TITLE
Github ability to comment on an issue

### DIFF
--- a/src/yetibot/api/github.clj
+++ b/src/yetibot/api/github.clj
@@ -233,6 +233,11 @@
   (with-url endpoint
     (issues/org-issues org-name auth)))
 
+(defn create-comment-on-issue
+  [org-name repo issue-number comment]
+  (with-url endpoint
+    (issues/create-comment org-name repo issue-number comment auth)))
+
 ;; search
 
 (defn search-pull-requests [org-name keywords & [opts]]

--- a/src/yetibot/commands/github.clj
+++ b/src/yetibot/commands/github.clj
@@ -262,6 +262,16 @@
      :result/collection-path [:items]
      :result/value (map :html_url items)}))
 
+(defn comment-on-issue-cmd
+  "gh comment <org>/<repo>#<issue_number> <comment> # post comment on given issue number for a Github repository"
+  [{[_ org-name repo issue-number comment] :match}]
+  (let [response (gh/create-comment-on-issue org-name repo issue-number comment)]
+    (or
+      (report-if-error response)
+      {:result/data response
+       :result/value (format "Comment added to issue #%s"
+                             issue-number)})))
+
 (when (gh/configured?)
   (cmd-hook {"gh" #"gh"
              "github" #"github"}
@@ -283,4 +293,5 @@
     #"branches\s+(\S+)\/(\S+)" branches
     #"releases\s+show\s+(\S+)\/(\S+)\s+(\S+)" show-release-info-by-tag-cmd
     #"releases\s+show\s+(\S+)\/(\S+)" show-latest-release-info-cmd
-    #"releases\s+(\S+)\/(\S+)" list-releases-info-cmd))
+    #"releases\s+(\S+)\/(\S+)" list-releases-info-cmd
+    #"comment\s+(\S+)\/(\S+)#(\d+)\s+(.+)" comment-on-issue-cmd))


### PR DESCRIPTION
👋 hello!

re: https://github.com/yetibot/yetibot/issues/899

qs:
- it was unclear to me where `:result/data` is used, and in the case of commenting what should be returned. the url of the comment perhaps? [here is response body](https://developer.github.com/v3/issues/comments/#response-3)
- what's the best way for me to test this? didn't see notes in the [contributing doc](https://github.com/yetibot/yetibot/blob/master/CONTRIBUTING.md)
- why do the cmd regex matchers use `\S`(any non-whitespace character)? afaik github repo names can contain letters, numbers, underscores, dashes, and periods. i bring this up because the regex parsing for my command (and others) will 'pass' but be incorrect if someone enters multiple "\s" or "#"s.

ex ->
```clojure
(def regex #"comment\s+(\S+)\/(\S+)#(\d+)\s+(.+)")

(def good-input  "comment org/repo#1 comment")
(refind regex good-input) -> ["comment org/repo#1 comment" "org" "repo" "1" "comment"]

(def bad-input "comment org//repo##1 comment")
(refind regex bad-input)-> ["comment org//repo##1 comment" "org/" "repo#" "1" "comment"]

```


