### PR TITLE
Upgrade to yetibot/core "20190913.182757.1838a79"

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -6,6 +6,10 @@ which contains Yetibot's core functionality along with a few commands. See
 changelog](https://github.com/yetibot/yetibot.core/blob/master/doc/CHANGELOG.md)
 as well.
 
+## 0.5.41 - 9/13/19
+
+- Upgrade to `yetibot/core "20190913.182757.1838a79"`
+
 ## 0.5.40 - 9/10/19
 
 - Upgrade to `yetibot/core "20190910.175122.9e253dd"`

--- a/project.clj
+++ b/project.clj
@@ -42,7 +42,7 @@
                    (println))}
 
   :dependencies [[org.clojure/clojure "1.10.0"]
-                 [yetibot/core "20190910.175122.9e253dd"]
+                 [yetibot/core "20190913.182757.1838a79"]
 
 
                  ; apis


### PR DESCRIPTION
Testing out the upgrade on a branch since the [changes in yetibot/core](https://github.com/yetibot/yetibot.core/blob/master/doc/CHANGELOG.md#yetibotcore-201909131827571838a79) are significant!