### PR TITLE
Add repo dispatch action to bump yetibot/core

### DIFF
--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -6,6 +6,7 @@ name: Handle repository dispatch events
 on:
   repository_dispatch:
     types: [bump]
+    branches: ["*"]
 
 jobs:
   bump:

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -1,0 +1,34 @@
+
+name: Handle repository dispatch events
+
+# this allows other repos to send a release dispatch here which then triggers a
+# version bump
+on:
+  repository_dispatch:
+    types: [bump]
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.YETIBOT_GITHUB_TOKEN}}
+
+      - name: Bump!
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+          echo "Upgrading to yetibot/core ${{ github.event.client_payload.message.yb_version }}"
+
+          # sed -i "s/^appVersion.*$/appVersion: ${{ github.event.client_payload.message.yb_version }}/" charts/yetibot/Chart.yaml
+          # # auto bump patch version (note: single quotes required):
+          # sed -i -r 's/^version: ([0-9]+)\.([0-9]+)\.([0-9]+)/echo version: \1.\2.$((\3+1))/ge' charts/yetibot/Chart.yaml
+          # git diff
+          # git add charts/yetibot/Chart.yaml
+          # git commit -m 'Use yetibot ${{ github.event.client_payload.message.yb_version }}'
+          #
+          # git push
+          #


### PR DESCRIPTION
Merging WIP as `repository_dispatch` events only run on master:
https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#repository_dispatch