### PR TITLE
docs: self-hosted lein-run deploy scripts (deploy/selfhosted/)

### DIFF
--- a/deploy/selfhosted/README.md
+++ b/deploy/selfhosted/README.md
@@ -1,0 +1,85 @@
+# Self-hosted Yetibot (lein-run on a box)
+
+This documents an **optional, manual** way to run Yetibot directly with
+`lein run` on a single host under systemd, with a poll-based auto-updater that
+tracks a git branch and redeploys when CI is green.
+
+This is **not** the production path — production is the Docker image deployed to
+Kubernetes via CI/CD. Use this for a dev/staging box (e.g. one reachable only
+over a private network) where you want trunk to roll out automatically without a
+container registry.
+
+## Topology
+
+- The bot runs as `yetibot.service` (`lein run`, `WorkingDirectory=/root/yetibot`).
+- `yetibot-autoupdate.timer` fires `yetibot-autoupdate.service` every 5 minutes.
+- The updater (`yetibot-autoupdate.sh`):
+  1. `git ls-remote` the tracked `core` and `yetibot` refs (free, no clone).
+  2. When a tracked SHA changes, queries the GitHub check-runs API and waits for
+     the `test` check to be **green** (publish/deploy jobs are ignored — core is
+     built from source here).
+  3. Builds `yetibot/core` from source (`lein install` in `/root/core`), pins
+     that version into `/root/yetibot/project.clj`, checks out the target
+     `yetibot` ref, and restarts `yetibot.service`.
+- Secrets (Gemini key, GitHub App key, Discord/Slack tokens, DB) live in
+  `/root/yetibot/config/config.edn` on the box and are **never** committed here.
+
+## Layout
+
+```
+deploy/selfhosted/
+  provision.sh                     # installs gh + bun + gemini CLI
+  yetibot-autoupdate.sh            # the poll-based updater
+  yetibot-autoupdate.env.example   # updater config (copy to /root/...)
+  systemd/
+    yetibot.service
+    yetibot-autoupdate.service
+    yetibot-autoupdate.timer
+    yetibot.service.d/20-gemini.conf
+```
+
+## Setup
+
+Assumes JVM + [Leiningen](https://leiningen.org) + Postgres are already present,
+the bot source is at `/root/yetibot`, and a core checkout is at `/root/core`.
+
+```bash
+# 1. Host tooling for the `agent` command (gh + bun + gemini)
+sudo bash deploy/selfhosted/provision.sh
+
+# 2. Updater config
+sudo cp deploy/selfhosted/yetibot-autoupdate.env.example /root/yetibot-autoupdate.env
+sudo install -m 0755 deploy/selfhosted/yetibot-autoupdate.sh /root/yetibot-autoupdate.sh
+#    edit /root/yetibot-autoupdate.env to point at the refs you want to track
+
+# 3. systemd units
+sudo cp deploy/selfhosted/systemd/yetibot.service /etc/systemd/system/
+sudo cp deploy/selfhosted/systemd/yetibot-autoupdate.service /etc/systemd/system/
+sudo cp deploy/selfhosted/systemd/yetibot-autoupdate.timer /etc/systemd/system/
+sudo mkdir -p /etc/systemd/system/yetibot.service.d
+sudo cp deploy/selfhosted/systemd/yetibot.service.d/20-gemini.conf /etc/systemd/system/yetibot.service.d/
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now yetibot.service yetibot-autoupdate.timer
+```
+
+## Operating
+
+```bash
+systemctl status yetibot
+journalctl -u yetibot -f
+tail -f /root/yetibot-autoupdate.log     # what the updater is doing
+systemctl start yetibot-autoupdate.service  # force an update check now
+```
+
+To track a branch instead of trunk, set `CORE_REF` / `YETIBOT_REF` (and the
+matching `*_URL` / `*_REPO` if it's on a fork) in `/root/yetibot-autoupdate.env`.
+
+## The `agent` command
+
+`agent <prompt>` hands the request to the Gemini CLI running headlessly, which
+uses the authenticated `gh` CLI (`GH_TOKEN`) and `git` to make changes and open
+PRs. That's why `provision.sh` installs gh + bun + gemini, and why the
+`20-gemini.conf` drop-in sets `GEMINI_CLI_TRUST_WORKSPACE=true` (the CLI refuses
+to run in an untrusted directory otherwise). Gemini + GitHub auth are configured
+in `config.edn` (`:gemini :key`, `:github :app`/`:token`).

--- a/deploy/selfhosted/provision.sh
+++ b/deploy/selfhosted/provision.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Provision the host tooling a self-hosted lein-run Yetibot needs, beyond the
+# JVM + Leiningen + Postgres you supply separately:
+#
+#   - gh         GitHub CLI (used by the `agent` command's Gemini runs)
+#   - bun        JS runtime used to install + run the Gemini CLI
+#   - gemini     Google Gemini CLI (the `agent` command shells out to it)
+#
+# Idempotent: re-running upgrades/repairs in place. Run as root.
+set -euo pipefail
+export PATH=/usr/local/bin:/usr/bin:/bin:/root/.bun/bin
+export BUN_INSTALL=/root/.bun
+
+echo "==> gh CLI"
+if ! command -v gh >/dev/null 2>&1; then
+  arch=$(uname -m); case "$arch" in x86_64) a=amd64;; aarch64|arm64) a=arm64;; *) a=amd64;; esac
+  ver=$(curl -fsSL https://api.github.com/repos/cli/cli/releases/latest \
+        | python3 -c 'import sys,json;print(json.load(sys.stdin)["tag_name"].lstrip("v"))')
+  curl -fsSL "https://github.com/cli/cli/releases/download/v${ver}/gh_${ver}_linux_${a}.tar.gz" -o /tmp/gh.tgz
+  tar xzf /tmp/gh.tgz -C /tmp
+  install -m 0755 "/tmp/gh_${ver}_linux_${a}/bin/gh" /usr/local/bin/gh
+  rm -rf /tmp/gh.tgz "/tmp/gh_${ver}_linux_${a}"
+fi
+gh --version | head -1
+
+echo "==> bun"
+if ! command -v bun >/dev/null 2>&1; then
+  curl -fsSL https://bun.sh/install | bash
+fi
+ln -sf /root/.bun/bin/bun /usr/local/bin/bun
+echo "bun $(bun --version)"
+
+echo "==> Gemini CLI (installed + run under bun)"
+bun install -g @google/gemini-cli
+ENTRY=/root/.bun/install/global/node_modules/@google/gemini-cli/bundle/gemini.js
+cat > /usr/local/bin/gemini <<EOF
+#!/usr/bin/env bash
+exec /usr/local/bin/bun "$ENTRY" "\$@"
+EOF
+chmod 0755 /usr/local/bin/gemini
+gemini --version | tail -1
+
+echo "==> done. gh + bun + gemini are on PATH for the systemd service."

--- a/deploy/selfhosted/systemd/yetibot-autoupdate.service
+++ b/deploy/selfhosted/systemd/yetibot-autoupdate.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Yetibot auto-update (pull green trunk/branch and restart)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+Environment=HOME=/root
+Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ExecStart=/root/yetibot-autoupdate.sh

--- a/deploy/selfhosted/systemd/yetibot-autoupdate.timer
+++ b/deploy/selfhosted/systemd/yetibot-autoupdate.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run yetibot auto-update every 5 minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+AccuracySec=30s
+
+[Install]
+WantedBy=timers.target

--- a/deploy/selfhosted/systemd/yetibot.service
+++ b/deploy/selfhosted/systemd/yetibot.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Yetibot (lein run)
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/root/yetibot
+Environment=HOME=/root
+Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ExecStart=/usr/bin/lein run
+Restart=on-failure
+RestartSec=10
+TimeoutStartSec=900
+KillMode=control-group
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/selfhosted/systemd/yetibot.service.d/20-gemini.conf
+++ b/deploy/selfhosted/systemd/yetibot.service.d/20-gemini.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment=GEMINI_CLI_TRUST_WORKSPACE=true

--- a/deploy/selfhosted/yetibot-autoupdate.env.example
+++ b/deploy/selfhosted/yetibot-autoupdate.env.example
@@ -1,0 +1,27 @@
+# Copy to /root/yetibot-autoupdate.env and adjust. No secrets are required for
+# the default (public-trunk) setup.
+
+# Refs to track. Point at a branch name to test that branch; default master.
+CORE_REF=master
+YETIBOT_REF=master
+
+# Source repos to build from (override to track a fork's branch). Public HTTPS,
+# no credentials needed.
+CORE_URL=https://github.com/yetibot/core.git
+YB_URL=https://github.com/yetibot/yetibot.git
+
+# owner/repo to query for CI status (match wherever the tracked branch's CI runs).
+CORE_REPO=yetibot/core
+YB_REPO=yetibot/yetibot
+
+# Which check-run name must be green before deploying. Publish/deploy jobs are
+# ignored on purpose — core is built from source here, so a Clojars/Docker step
+# is irrelevant.
+REQUIRED_CHECK=test
+
+# Optional GitHub token to raise the check-runs API rate limit. Public repos work
+# fine unauthenticated since the API is only queried when a tracked SHA changes.
+GITHUB_TOKEN=
+
+# Set to 1 to detect + log only (no build/restart).
+DRY_RUN=0

--- a/deploy/selfhosted/yetibot-autoupdate.sh
+++ b/deploy/selfhosted/yetibot-autoupdate.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Auto-update the lein-run yetibot instance when a tracked ref's CI is green.
+# Tracks yetibot/core and yetibot/yetibot at refs configured in the env file
+# (default: master). SHA detection uses git fetch (free); the GitHub check-runs
+# REST API is only queried when a ref's head SHA changes, so steady-state API
+# usage is ~0 and stays well under the unauthenticated 60 req/hour limit.
+
+set -uo pipefail
+
+ENV_FILE=/root/yetibot-autoupdate.env
+STATE_FILE=/root/.yetibot-autoupdate.state
+LOCK_FILE=/root/.yetibot-autoupdate.lock
+CORE_DIR=/root/core
+YB_DIR=/root/yetibot
+LOG=/root/yetibot-autoupdate.log
+
+exec >>"$LOG" 2>&1
+exec 9>"$LOCK_FILE"
+flock -n 9 || { echo "$(date -u +%FT%TZ) lock held, skipping"; exit 0; }
+
+log() { echo "$(date -u +%FT%TZ) $*"; }
+
+CORE_REF=master
+YETIBOT_REF=master
+CORE_URL=https://github.com/yetibot/core.git
+YB_URL=https://github.com/yetibot/yetibot.git
+# owner/repo to query for CI status (set to a fork when tracking its branch)
+CORE_REPO=yetibot/core
+YB_REPO=yetibot/yetibot
+REQUIRED_CHECK=test
+DRY_RUN=0
+GITHUB_TOKEN=""
+# shellcheck disable=SC1090
+[ -f "$ENV_FILE" ] && . "$ENV_FILE"
+
+AUTH=()
+[ -n "$GITHUB_TOKEN" ] && AUTH=(-H "Authorization: Bearer $GITHUB_TOKEN")
+
+CORE_DEPLOYED=""
+YB_DEPLOYED=""
+CORE_VERSION=""
+# shellcheck disable=SC1090
+[ -f "$STATE_FILE" ] && . "$STATE_FILE"
+
+remote_sha() { # <url> <ref> -> prints head sha; ls-remote over HTTPS (no creds)
+  git ls-remote "$1" "$2" 2>/dev/null | awk 'NR==1 {print $1}'
+}
+
+ci_state() { # <owner/repo> <sha> -> prints green|pending|failed|none|error
+  # Gates on the test check(s) only (REQUIRED_CHECK). Publish/deploy jobs are
+  # ignored: the bot builds core from source, so a cancelled/failed Clojars
+  # deploy must not block updates.
+  local json
+  json=$(curl -fsSL --max-time 30 "${AUTH[@]}" -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/repos/$1/commits/$2/check-runs" 2>/dev/null) || { echo error; return; }
+  printf '%s' "$json" | REQUIRED_CHECK="$REQUIRED_CHECK" python3 -c '
+import json,os,sys
+req=os.environ.get("REQUIRED_CHECK","test")
+d=json.load(sys.stdin)
+runs=[r for r in d.get("check_runs",[]) if r.get("name")==req]
+if not runs:
+    print("none"); raise SystemExit
+if any(r.get("status")!="completed" for r in runs):
+    print("pending"); raise SystemExit
+if any((r.get("conclusion") or "")!="success" for r in runs):
+    print("failed"); raise SystemExit
+print("green")
+' 2>/dev/null || echo error
+}
+
+write_state() {
+  cat >"$STATE_FILE" <<EOF
+CORE_DEPLOYED=$1
+YB_DEPLOYED=$2
+CORE_VERSION=$3
+EOF
+}
+
+log "checking core@$CORE_REF yetibot@$YETIBOT_REF (dry_run=$DRY_RUN)"
+
+core_sha=$(remote_sha "$CORE_URL" "$CORE_REF")
+yb_sha=$(remote_sha "$YB_URL" "$YETIBOT_REF")
+[ -n "$core_sha" ] || { log "ERROR: could not resolve core@$CORE_REF from $CORE_URL"; exit 1; }
+[ -n "$yb_sha" ]   || { log "ERROR: could not resolve yetibot@$YETIBOT_REF from $YB_URL"; exit 1; }
+
+target_core_sha=$CORE_DEPLOYED
+target_yb_sha=$YB_DEPLOYED
+core_rebuilt=0
+deploy_yb=0
+
+# --- core ---
+if [ "$core_sha" != "$CORE_DEPLOYED" ]; then
+  st=$(ci_state "$CORE_REPO" "$core_sha")
+  log "core $core_sha ci=$st"
+  if [ "$st" = green ]; then
+    if [ "$DRY_RUN" = 1 ]; then
+      log "[dry-run] would build+install core@$core_sha"
+      target_core_sha=$core_sha
+    else
+      log "building core@$core_sha"
+      git -C "$CORE_DIR" fetch -q "$CORE_URL" "$CORE_REF"
+      git -C "$CORE_DIR" checkout -q -f "$core_sha"
+      if (cd "$CORE_DIR" && lein install) >/tmp/yetibot-core-install.log 2>&1; then
+        ver=$(grep -oE '/target/core-[0-9][^ ]*\.jar' /tmp/yetibot-core-install.log | head -1 | sed -E 's#.*/core-(.*)\.jar$#\1#')
+        if [ -n "$ver" ]; then
+          CORE_VERSION=$ver
+          target_core_sha=$core_sha
+          core_rebuilt=1
+          log "installed core $CORE_VERSION"
+        else
+          log "ERROR: could not parse installed core version"
+        fi
+      else
+        log "ERROR: core lein install failed (see /tmp/yetibot-core-install.log)"
+      fi
+    fi
+  fi
+fi
+
+# --- yetibot ---
+if [ "$yb_sha" != "$YB_DEPLOYED" ]; then
+  st=$(ci_state "$YB_REPO" "$yb_sha")
+  log "yetibot $yb_sha ci=$st"
+  if [ "$st" = green ]; then
+    deploy_yb=1
+    target_yb_sha=$yb_sha
+  fi
+fi
+
+if [ "$DRY_RUN" = 1 ]; then
+  log "[dry-run] core_rebuilt=$core_rebuilt deploy_yb=$deploy_yb -> done"
+  exit 0
+fi
+
+if [ "$core_rebuilt" = 0 ] && [ "$deploy_yb" = 0 ]; then
+  log "nothing to deploy"
+  exit 0
+fi
+
+# Need a core version to pin against.
+if [ -z "$CORE_VERSION" ]; then
+  log "ERROR: no core version available to pin; aborting"
+  exit 1
+fi
+
+# Check out the target yetibot ref cleanly (discarding the local dep pin), then
+# re-pin the core dependency to the locally built version and restart.
+git -C "$YB_DIR" fetch -q "$YB_URL" "$YETIBOT_REF"
+git -C "$YB_DIR" checkout -q -f "$target_yb_sha"
+( cd "$YB_DIR" && lein update-dependency yetibot/core "$CORE_VERSION" ) >/tmp/yetibot-pin.log 2>&1 \
+  || { log "ERROR: lein update-dependency failed (see /tmp/yetibot-pin.log)"; exit 1; }
+log "pinned yetibot/core -> $CORE_VERSION on yetibot@$target_yb_sha"
+
+if systemctl restart yetibot; then
+  write_state "$target_core_sha" "$target_yb_sha" "$CORE_VERSION"
+  log "restarted yetibot (core=$CORE_VERSION yetibot=$target_yb_sha)"
+else
+  log "ERROR: systemctl restart yetibot failed"
+  exit 1
+fi


### PR DESCRIPTION
Documents the optional self-hosted topology: `lein run` under systemd with a poll-based auto-updater that tracks a branch and redeploys on green CI. Not the prod path (Docker/k8s) — for a dev/staging box.

Includes systemd units, the updater + env template, a `provision.sh` for the host tooling the `agent` command needs (gh + bun + gemini CLI), and a README. No secrets (those live in `config.edn` on the host).